### PR TITLE
Fix text and link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Official React bindings for Fela.
 
 </p>
 <br>
-This package only includes React bindings for [ Fela](http://github.com/rofrischmann/fela). <br>
+
+This package only includes React bindings for [Fela](http://github.com/rofrischmann/fela). <br>
 It assumes you already know about Fela and how to use it.
 
 > [Learn about Fela!](http://github.com/rofrischmann/fela)


### PR DESCRIPTION
Seems like some of the markdown in the README wasn't being rendered correctly. This patch should fix it up.

Here's the visual diff
![image](https://cloud.githubusercontent.com/assets/318208/26243425/bd365fd6-3c83-11e7-9a20-ae752a29f089.png)
